### PR TITLE
Fix firmware upgrades being blocked when using https

### DIFF
--- a/tasmoadmin/rootfs/etc/nginx/nginx-ssl.conf
+++ b/tasmoadmin/rootfs/etc/nginx/nginx-ssl.conf
@@ -34,6 +34,9 @@ http {
         add_header X-XSS-Protection "1; mode=block";
         add_header X-Robots-Tag none;
 
+        location /data/firmwares {
+        }
+
         location /data/ {
             deny all;
         }


### PR DESCRIPTION
# Proposed Changes
Fixes the same issue as in https://github.com/hassio-addons/addon-tasmoadmin/commit/efed129ae160fb227e2bcaa9ae0f585aeb3adef9 but for https.

I didn't test it to be honest as the issue is quite clear when you know about the commit referenced above and as I didn't know how I could create an easy test setup. Please let me know if you have concerns.