### PR TITLE
Update DOCS.md

### DIFF
--- a/tasmoadmin/DOCS.md
+++ b/tasmoadmin/DOCS.md
@@ -31,7 +31,6 @@ log_level: info
 ssl: false
 certfile: fullchain.pem
 keyfile: privkey.pem
-ipv6: true
 ```
 
 **Note**: _This is just an example, don't copy and past it! Create your own!_
@@ -72,10 +71,6 @@ The certificate file to use for SSL.
 The private key file to use for SSL.
 
 **Note**: _The file MUST be stored in `/ssl/`, which is the default_
-
-### Option: `ipv6`
-
-Set this option too `false` to disable IPv6 support.
 
 ## Embedding into Home Assistant
 


### PR DESCRIPTION
There is no IPV6 option in config.json causing a supervisor error if enabled
"WARNING (MainThread) [supervisor.addons.validate] Unknown options ipv6"

# Proposed Changes

remove the references to IPV6

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/