### PR TITLE
add home-assistant ingress support

### DIFF
--- a/tasmoadmin/config.json
+++ b/tasmoadmin/config.json
@@ -4,7 +4,6 @@
   "slug": "sonweb",
   "description": "Centrally manage all your Sonoff-Tasmota devices",
   "url": "https://github.com/hassio-addons/addon-tasmoadmin",
-  "webui": "[PROTO:ssl]://[HOST]:[PORT:9541]",
   "startup": "system",
   "init": false,
   "arch": ["aarch64", "amd64", "armhf", "armv7", "i386"],

--- a/tasmoadmin/config.json
+++ b/tasmoadmin/config.json
@@ -9,6 +9,8 @@
   "init": false,
   "arch": ["aarch64", "amd64", "armhf", "armv7", "i386"],
   "map": ["ssl"],
+  "ingress": true,
+  "ingress_port": 9541,
   "ports": {
     "9541/tcp": 9541
   },

--- a/tasmoadmin/rootfs/etc/nginx/nginx-ssl.conf
+++ b/tasmoadmin/rootfs/etc/nginx/nginx-ssl.conf
@@ -44,6 +44,7 @@ http {
             fastcgi_split_path_info ^(.+\.php)(/.+)$;
             fastcgi_index index.php;
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+            fastcgi_param TASMO_BASEURL $http_x_ingress_path/;
             include fastcgi_params;
         }
 

--- a/tasmoadmin/rootfs/etc/nginx/nginx.conf
+++ b/tasmoadmin/rootfs/etc/nginx/nginx.conf
@@ -31,6 +31,7 @@ http {
             fastcgi_split_path_info ^(.+\.php)(/.+)$;
             fastcgi_index index.php;
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+            fastcgi_param TASMO_BASEURL $http_x_ingress_path/;
             include fastcgi_params;
         }
 


### PR DESCRIPTION
# Proposed Changes

Home-assistant ingress has been there for a long time, we should support it.

What I did was a simple fix: add ingress config and set TASMO_BASEURL to the correct X_INGRESS_PATH set by home-assistant. The header will be empty when visiting the domain directly so it's still the correct base_url

## Related Issues

#44 #47 #59 #62
