### PR TITLE
⬆️ Upgrades php7 to 7.4.28

### DIFF
--- a/tasmoadmin/Dockerfile
+++ b/tasmoadmin/Dockerfile
@@ -9,13 +9,13 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN \
     apk add --no-cache \
         nginx=1.20.2-r0 \
-        php7-curl=7.4.27-r0 \
-        php7-fpm=7.4.27-r0 \
-        php7-json=7.4.27-r0 \
-        php7-opcache=7.4.27-r0 \
-        php7-session=7.4.27-r0 \
-        php7-zip=7.4.27-r0 \
-        php7=7.4.27-r0 \
+        php7-curl=7.4.28-r0 \
+        php7-fpm=7.4.28-r0 \
+        php7-json=7.4.28-r0 \
+        php7-opcache=7.4.28-r0 \
+        php7-session=7.4.28-r0 \
+        php7-zip=7.4.28-r0 \
+        php7=7.4.28-r0 \
     \
     && apk add --no-cache --virtual .build-dependencies \
         git=2.34.1-r0 \


### PR DESCRIPTION
# Proposed Changes

Bump PHP to 7.4.28 to allow building the image.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
