### PR TITLE
Add non-SSL support for OTA when using SSL

### DIFF
--- a/tasmoadmin/config.yaml
+++ b/tasmoadmin/config.yaml
@@ -18,8 +18,10 @@ map:
   - ssl
 ports:
   9541/tcp: 9541
+  9542/tcp: 9542
 ports_description:
   9541/tcp: TasmoAdmin web interface
+  9542/tcp: TasmoAdmin HTTP OTA download only
 options:
   ssl: true
   certfile: fullchain.pem

--- a/tasmoadmin/rootfs/etc/nginx/nginx-ssl.conf
+++ b/tasmoadmin/rootfs/etc/nginx/nginx-ssl.conf
@@ -14,6 +14,15 @@ http {
 
     server {
         server_name hassio.local;
+        listen 9542 default_server;
+        root /var/www/tasmoadmin/tasmoadmin/;
+
+        location /data/firmwares {
+        }
+    }
+
+    server {
+        server_name hassio.local;
         listen 9541 default_server ssl;
         root /var/www/tasmoadmin/tasmoadmin;
         index index.php;
@@ -32,6 +41,9 @@ http {
         add_header X-Content-Type-Options nosniff;
         add_header X-XSS-Protection "1; mode=block";
         add_header X-Robots-Tag none;
+
+        location /data/firmwares {
+        }
 
         location /data/ {
             deny all;

--- a/tasmoadmin/rootfs/etc/nginx/nginx.conf
+++ b/tasmoadmin/rootfs/etc/nginx/nginx.conf
@@ -14,6 +14,15 @@ http {
 
     server {
         server_name hassio.local;
+        listen 9542 default_server;
+        root /var/www/tasmoadmin/tasmoadmin/;
+
+        location /data/firmwares {
+        }
+    }
+
+    server {
+        server_name hassio.local;
         listen 9541 default_server;
         root /var/www/tasmoadmin/tasmoadmin/;
         index index.php;


### PR DESCRIPTION
# Proposed Changes

With this change, nginx will bind on an additional port 9542 in HTTP mode whether SSL is enabled or not.
This non SSL port allow access only to the subpath /data/firmwares for firmware downloads.
Tasmota doesn't support SSL/TLS by default so this workaround will make local firmware upgrades possible without compromising TLS access to the web UI.
Access to /data/firmwares is also enabled on TLS port, for future compability.
