### PR TITLE
Fix PHP opcache blacklist file

### DIFF
--- a/tasmoadmin/rootfs/etc/php8/conf.d/99-tasmoadmin.ini
+++ b/tasmoadmin/rootfs/etc/php8/conf.d/99-tasmoadmin.ini
@@ -6,4 +6,4 @@ opcache.max_accelerated_files=4096
 opcache.memory_consumption=32
 opcache.revalidate_freq=0
 opcache.validate_timestamps=0
-opcache.blacklist_filename=/etc/php7/blacklist.txt
+opcache.blacklist_filename=/etc/php8/blacklist.txt


### PR DESCRIPTION
# Proposed Changes

This was missed in the PHP7->PHP8 upgrade
