### PR TITLE
Bump PHP to 8.0.24-r0

### DIFF
--- a/tasmoadmin/Dockerfile
+++ b/tasmoadmin/Dockerfile
@@ -10,14 +10,14 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN \
     apk add --no-cache \
         nginx=1.22.0-r1 \
-        php8-curl=8.0.22-r0 \
-        php8-fpm=8.0.22-r0 \
-        php8-iconv=8.0.22-r0 \
-        php8-mbstring=8.0.22-r0 \
-        php8-opcache=8.0.22-r0 \
-        php8-session=8.0.22-r0 \
-        php8-zip=8.0.22-r0 \
-        php8=8.0.22-r0 \
+        php8-curl=8.0.24-r0 \
+        php8-fpm=8.0.24-r0 \
+        php8-iconv=8.0.24-r0 \
+        php8-mbstring=8.0.24-r0 \
+        php8-opcache=8.0.24-r0 \
+        php8-session=8.0.24-r0 \
+        php8-zip=8.0.24-r0 \
+        php8=8.0.24-r0 \
     \
     && apk add --no-cache --virtual .build-dependencies \
         composer=2.4.1-r0 \


### PR DESCRIPTION
# Proposed Changes

Bump PHP to be able to build new image.

In theory once we merge #259 we should be able to use PHP 8.1

## Related Issues

N/A
