### PR TITLE
Include node_modules in final image

### DIFF
--- a/tasmoadmin/Dockerfile
+++ b/tasmoadmin/Dockerfile
@@ -34,7 +34,7 @@ RUN \
     \
     && npm ci \
     && node minify.js \
-    && NODE_ENV=production npm ci
+    && NODE_ENV=production npm ci \
     \
     && apk del --no-cache --purge .build-dependencies \
     \

--- a/tasmoadmin/Dockerfile
+++ b/tasmoadmin/Dockerfile
@@ -34,6 +34,7 @@ RUN \
     \
     && npm ci \
     && node minify.js \
+    && NODE_ENV=production npm ci
     \
     && apk del --no-cache --purge .build-dependencies \
     \
@@ -45,7 +46,6 @@ RUN \
         /var/www/tasmoadmin/.github \
         /var/www/tasmoadmin/.iocage \
         /var/www/tasmoadmin/docker-compose.yml \
-        /var/www/tasmoadmin/tasmoadmin/node_modules \
         /var/www/tasmoadmin/tasmoadmin/tests \
     \
     && find /var/www/tasmoadmin -type f -name ".htaccess" -depth -exec rm -f {} \; \


### PR DESCRIPTION
# Proposed Changes

When testing the edge addon I noticed the `node_modules` removal since we now require this as front-end assets are managed unpacked right now from there.

Will investigate improving that since there is some bloat in that dir even with dev dependencies ommited.

- NODE_ENV=production npm ci to omit dev dependencies
- Include `node_modules`

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
