### PR TITLE
🔨 Change nginx configuration for v3 upgrade

### DIFF
--- a/tasmoadmin/rootfs/etc/nginx/nginx-ssl.conf
+++ b/tasmoadmin/rootfs/etc/nginx/nginx-ssl.conf
@@ -33,33 +33,27 @@ http {
         add_header X-XSS-Protection "1; mode=block";
         add_header X-Robots-Tag none;
 
+        location /data/firmwares {
+            add_header Access-Control-Allow-Origin *;
+        }
+
         location /data/ {
             deny all;
         }
 
-        location ~ .php$ {
+        location ~ ^/index\.php(/|$) {
             fastcgi_pass 127.0.0.1:9001;
             fastcgi_read_timeout 900;
-            fastcgi_split_path_info ^(.+\.php)(/.+)$;
-            fastcgi_index index.php;
-            fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+            fastcgi_split_path_info ^(.+\.php)(/.*)$;
             include fastcgi_params;
+
+            fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
+            fastcgi_param DOCUMENT_ROOT $realpath_root;
+
+            internal;
         }
 
         location ~ ^(.*)\.(css|js|gif||jpe?g|png|json|cache\.json)$ {
-        }
-
-        location / {
-            rewrite ^/login$ /login.php last;
-            rewrite ^/logout$ /login.php?logout=logout last;
-            rewrite ^/doAjaxAll$ /index.php?doAjaxAll=doAjaxAll last;
-            rewrite ^/doAjax$ /index.php?doAjax=doAjax last;
-            rewrite "/([a-z]{2})/" /index.php?lang=$1 last;
-            rewrite ^/([a-zA-Z_]+)/([a-zA-Z_]+)/([0-9_]+)/?$ /index.php?page=$1&action=$2&device_id=$3;
-            rewrite ^/([a-zA-Z_]+)/(force)/?$ /index.php?page=$1&force=1;
-            rewrite ^/([a-zA-Z_]+)/([a-zA-Z_]+)/?$ /index.php?page=$1&action=$2;
-            rewrite ^/([a-zA-Z_]+)/([0-9]+)/?$ /index.php?page=$1&device_id=$2;
-            rewrite ^/([a-zA-Z_]+)/?$ /index.php?page=$1;
         }
     }
 }

--- a/tasmoadmin/rootfs/etc/nginx/nginx.conf
+++ b/tasmoadmin/rootfs/etc/nginx/nginx.conf
@@ -19,35 +19,26 @@ http {
         index index.php;
 
         location /data/firmwares {
+            add_header Access-Control-Allow-Origin *;
         }
 
         location /data/ {
             deny all;
         }
 
-        location ~ .php$ {
+        location ~ ^/index\.php(/|$) {
             fastcgi_pass 127.0.0.1:9001;
             fastcgi_read_timeout 900;
-            fastcgi_split_path_info ^(.+\.php)(/.+)$;
-            fastcgi_index index.php;
-            fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+            fastcgi_split_path_info ^(.+\.php)(/.*)$;
             include fastcgi_params;
+
+            fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
+            fastcgi_param DOCUMENT_ROOT $realpath_root;
+
+            internal;
         }
 
         location ~ ^(.*)\.(css|js|gif||jpe?g|png|json|cache\.json)$ {
-        }
-
-        location / {
-            rewrite ^/login$ /login.php last;
-            rewrite ^/logout$ /login.php?logout=logout last;
-            rewrite ^/doAjaxAll$ /index.php?doAjaxAll=doAjaxAll last;
-            rewrite ^/doAjax$ /index.php?doAjax=doAjax last;
-            rewrite "/([a-z]{2})/" /index.php?lang=$1 last;
-            rewrite ^/([a-zA-Z_]+)/([a-zA-Z_]+)/([0-9_]+)/?$ /index.php?page=$1&action=$2&device_id=$3;
-            rewrite ^/([a-zA-Z_]+)/(force)/?$ /index.php?page=$1&force=1;
-            rewrite ^/([a-zA-Z_]+)/([a-zA-Z_]+)/?$ /index.php?page=$1&action=$2;
-            rewrite ^/([a-zA-Z_]+)/([0-9]+)/?$ /index.php?page=$1&device_id=$2;
-            rewrite ^/([a-zA-Z_]+)/?$ /index.php?page=$1;
         }
     }
 }


### PR DESCRIPTION
# Proposed Changes

With the v3 upgrade along with the PHP 8.1 bump the routing was moved internally which means we can drop the nginx rewrites and push everything through the front controller.

Configuration derived from https://symfony.com/doc/current/setup/web_server_configuration.html

Also added `Access-Control-Allow-Origin` to the firmware dir to make the front-end check for firmware accessibility to work as on the addon I had issues without this when it did a HEAD request.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
