### PR TITLE
🐛 Fix nginx routing for /

### DIFF
--- a/tasmoadmin/rootfs/etc/nginx/nginx-ssl.conf
+++ b/tasmoadmin/rootfs/etc/nginx/nginx-ssl.conf
@@ -16,7 +16,6 @@ http {
         server_name hassio.local;
         listen 9541 default_server ssl;
         root /var/www/tasmoadmin/tasmoadmin;
-        index index.php;
 
         ssl_certificate /ssl/%%certfile%%;
         ssl_certificate_key /ssl/%%keyfile%%;
@@ -32,6 +31,10 @@ http {
         add_header X-Content-Type-Options nosniff;
         add_header X-XSS-Protection "1; mode=block";
         add_header X-Robots-Tag none;
+
+        location / {
+            try_files $uri /index.php$is_args$args;
+        }
 
         location /data/firmwares {
             add_header Access-Control-Allow-Origin *;

--- a/tasmoadmin/rootfs/etc/nginx/nginx.conf
+++ b/tasmoadmin/rootfs/etc/nginx/nginx.conf
@@ -16,7 +16,10 @@ http {
         server_name hassio.local;
         listen 9541 default_server;
         root /var/www/tasmoadmin/tasmoadmin/;
-        index index.php;
+
+        location / {
+            try_files $uri /index.php$is_args$args;
+        }
 
         location /data/firmwares {
             add_header Access-Control-Allow-Origin *;


### PR DESCRIPTION
# Proposed Changes

In #289 I modified the routes but forgot to include:

```
        location / {
            try_files $uri /index.php$is_args$args;
        }
```

I think `index index.php;` is not requires since it's all handled within application.

How can i easily test this locally? when building the image and trying to run it hangs on `s6-rc: info: service base-addon-banner: starting`

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
