### PR TITLE
⬆️  Upgrades TasmoAdmin to v4.0.1

### DIFF
--- a/tasmoadmin/Dockerfile
+++ b/tasmoadmin/Dockerfile
@@ -5,7 +5,7 @@ ARG BUILDER=ghcr.io/hassio-addons/base-nodejs:0.1.3
 FROM ${BUILDER} AS builder
 
 # Setup base
-ARG TASMOADMIN_VERSION="v4.0.0"
+ARG TASMOADMIN_VERSION="v4.0.1"
 
 # hadolint ignore=DL3003
 RUN \

--- a/tasmoadmin/Dockerfile
+++ b/tasmoadmin/Dockerfile
@@ -33,7 +33,6 @@ RUN \
     \
     && npm ci \
     && npm run build \
-    && rm -rf node_modules \
     \
     && apk del --no-cache --purge .build-dependencies \
     \
@@ -45,6 +44,7 @@ RUN \
         /var/www/tasmoadmin/.github \
         /var/www/tasmoadmin/.iocage \
         /var/www/tasmoadmin/docker-compose.yml \
+        /var/www/tasmoadmin/node_modules \
         /var/www/tasmoadmin/tasmoadmin/tests \
     \
     && find /var/www/tasmoadmin -type f -name ".htaccess" -depth -exec rm -f {} \; \

--- a/tasmoadmin/Dockerfile
+++ b/tasmoadmin/Dockerfile
@@ -6,7 +6,7 @@ FROM ${BUILD_FROM}
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Setup base
-ARG TASMOADMIN_VERSION="v3.3.3"
+ARG TASMOADMIN_VERSION="v4.0.0"
 # hadolint ignore=DL3003
 RUN \
     apk add --no-cache \
@@ -32,8 +32,8 @@ RUN \
     && composer install --no-dev \
     \
     && npm ci \
-    && node minify.js \
-    && NODE_ENV=production npm ci \
+    && npm run build \
+    && rm -rf node_modules \
     \
     && apk del --no-cache --purge .build-dependencies \
     \


### PR DESCRIPTION
# Proposed Changes

The major version bump is because of the frontend buildchain change which now has an `npm build` which takes care of everything.

Comes with the added bonus of not needing to include `node_modules` which brings the whole image down in size too!

```
tasmoadmin                                 before               baec78957941   About a minute ago   208MB
tasmoadmin                                 after                dec6ecd71462   3 minutes ago        182MB
```

Still seems quite big? I guess we could change the base image to be just vanilla alpine? 

Tested by copying into my addon on my local instance and running there and all seems working from testing.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
