### PR TITLE
Change base image for smaller builds

### DIFF
--- a/tasmoadmin/Dockerfile
+++ b/tasmoadmin/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=ghcr.io/hassio-addons/base-nodejs:0.1.3
+ARG BUILD_FROM=ghcr.io/hassio-addons/base:15.0.6
 # hadolint ignore=DL3006
 FROM ${BUILD_FROM}
 
@@ -24,6 +24,8 @@ RUN \
     && apk add --no-cache --virtual .build-dependencies \
         composer=2.6.6-r0 \
         git=2.43.0-r0 \
+        nodejs=20.11.0-r0 \
+        npm=10.2.5-r0 \
     \
     && git clone --branch "${TASMOADMIN_VERSION}" --depth=1 \
         "https://github.com/TasmoAdmin/TasmoAdmin.git" /var/www/tasmoadmin \

--- a/tasmoadmin/build.yaml
+++ b/tasmoadmin/build.yaml
@@ -1,8 +1,8 @@
 ---
 build_from:
-  aarch64: ghcr.io/hassio-addons/base-nodejs:0.1.3
-  amd64: ghcr.io/hassio-addons/base-nodejs:0.1.3
-  armv7: ghcr.io/hassio-addons/base-nodejs:0.1.3
+  aarch64: ghcr.io/hassio-addons/base:15.0.6
+  amd64: ghcr.io/hassio-addons/base:15.0.6
+  armv7: ghcr.io/hassio-addons/base:15.0.6
 codenotary:
   base_image: codenotary@frenck.dev
   signer: codenotary@frenck.dev


### PR DESCRIPTION
# Proposed Changes

Not sure what the correct way to describe the title change to reflect changing the base image to meet your guidelines so please advice.

I noticed that the final image has node baked in which it does not need and this change leverages your generic base image instead.

```
tasmoadmin                                 after                a6f89cf30ae5   27 seconds ago   83.4MB
tasmoadmin                                 before               baec78957941   8 minutes ago    208MB
```

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
