### PR TITLE
Use non-nodejs base image

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,6 +11,7 @@
       "matchStringsStrategy": "any",
       "matchStrings": [
         "ARG BUILD_FROM=(?<depName>.*?):(?<currentValue>.*?)\\s+",
+        "ARG BUILDER=(?<depName>.*?):(?<currentValue>.*?)\\s+",
         "(aarch64|amd64|armhf|armv7|i386):\\s[\"']?(?<depName>.*?):(?<currentValue>.*?)[\"']?\\s"
       ],
       "datasourceTemplate": "docker"

--- a/tasmoadmin/Dockerfile
+++ b/tasmoadmin/Dockerfile
@@ -1,12 +1,33 @@
-ARG BUILD_FROM=ghcr.io/hassio-addons/base-nodejs:0.1.3
+ARG BUILD_FROM=ghcr.io/hassio-addons/base:15.0.6
+ARG BUILDER=ghcr.io/hassio-addons/base-nodejs:0.1.3
+
+# hadolint ignore=DL3006
+FROM ${BUILDER} AS builder
+
+# Setup base
+ARG TASMOADMIN_VERSION="v3.3.3"
+
+# hadolint ignore=DL3003
+RUN \
+    apk add --no-cache \
+        git=2.43.0-r0 \
+    \
+    && git clone --branch "${TASMOADMIN_VERSION}" --depth=1 \
+        "https://github.com/TasmoAdmin/TasmoAdmin.git" /var/www/tasmoadmin \
+    \
+    && cd /var/www/tasmoadmin/tasmoadmin \
+    && npm ci \
+    && node minify.js \
+    && NODE_ENV=production npm ci
+
 # hadolint ignore=DL3006
 FROM ${BUILD_FROM}
 
 # Set shell
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-# Setup base
-ARG TASMOADMIN_VERSION="v3.3.3"
+COPY --from=builder /var/www/tasmoadmin/tasmoadmin /var/www/tasmoadmin/tasmoadmin
+
 # hadolint ignore=DL3003
 RUN \
     apk add --no-cache \
@@ -23,17 +44,9 @@ RUN \
     \
     && apk add --no-cache --virtual .build-dependencies \
         composer=2.6.6-r0 \
-        git=2.43.0-r0 \
-    \
-    && git clone --branch "${TASMOADMIN_VERSION}" --depth=1 \
-        "https://github.com/TasmoAdmin/TasmoAdmin.git" /var/www/tasmoadmin \
     \
     && cd /var/www/tasmoadmin/tasmoadmin \
     && composer install --no-dev \
-    \
-    && npm ci \
-    && node minify.js \
-    && NODE_ENV=production npm ci \
     \
     && apk del --no-cache --purge .build-dependencies \
     \

--- a/tasmoadmin/build.yaml
+++ b/tasmoadmin/build.yaml
@@ -1,8 +1,8 @@
 ---
 build_from:
-  aarch64: ghcr.io/hassio-addons/base-nodejs:0.1.3
-  amd64: ghcr.io/hassio-addons/base-nodejs:0.1.3
-  armv7: ghcr.io/hassio-addons/base-nodejs:0.1.3
+  aarch64: ghcr.io/hassio-addons/base:15.0.6
+  amd64: ghcr.io/hassio-addons/base:15.0.6
+  armv7: ghcr.io/hassio-addons/base:15.0.6
 codenotary:
   base_image: codenotary@frenck.dev
   signer: codenotary@frenck.dev


### PR DESCRIPTION
# Proposed Changes

Use builder image to perform asset build and copy into image that will run the application.

Will require modification if #381 is merged first or vice versa.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
