### PR TITLE
Change nginx startup logic to ensure file permission on every startup

### DIFF
--- a/tasmoadmin/rootfs/etc/s6-overlay/s6-rc.d/init-tasmoadmin/run
+++ b/tasmoadmin/rootfs/etc/s6-overlay/s6-rc.d/init-tasmoadmin/run
@@ -11,12 +11,12 @@ if ! bashio::fs.directory_exists "/data/tasmoadmin"; then
 
     # Setup structure
     cp -R /var/www/tasmoadmin/data /data/tasmoadmin
-
-    # Ensure file permissions
-    chown -R nginx:nginx /data/tasmoadmin
-    find /data/tasmoadmin -not -perm 0644 -type f -exec chmod 0644 {} \;
-    find /data/tasmoadmin -not -perm 0755 -type d -exec chmod 0755 {} \;
 fi
+
+# Ensure file permissions
+chown -R nginx:nginx /data/tasmoadmin
+find /data/tasmoadmin -not -perm 0644 -type f -exec chmod 0644 {} \;
+find /data/tasmoadmin -not -perm 0755 -type d -exec chmod 0755 {} \;
 
 bashio::log.debug 'Symlinking data directory to persistent storage location...'
 rm -f -r /var/www/tasmoadmin/data


### PR DESCRIPTION
# Proposed Changes

This changes the startup logic of nginx to always set the data directory's file permissions. The script checks if the data directory already exists and if not, creates it and ensures appropriate permissions for nginx to be able to serve the firmware files from there. If the data directory already exists, but has broken permissions, this is not detected and fixed and results in non-functional OTA. With this change, the permissions are set on every startup, ensuring that any broken permissions are corrected.

## Related Issues

https://github.com/hassio-addons/addon-tasmoadmin/issues/457

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated system behavior to ensure consistent application of access permissions for core data directories. This change guarantees that proper file permissions are enforced regardless of whether the directory is newly created or pre-existing, leading to improved operational consistency and enhanced system reliability. This update further bolsters overall performance and maintains robust permission settings across all usage scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->