### PR TITLE
🐛 Fix path to  PHP opcache blacklist

### DIFF
--- a/tasmoadmin/rootfs/etc/php83/conf.d/99-tasmoadmin.ini
+++ b/tasmoadmin/rootfs/etc/php83/conf.d/99-tasmoadmin.ini
@@ -6,4 +6,4 @@ opcache.max_accelerated_files=4096
 opcache.memory_consumption=32
 opcache.revalidate_freq=0
 opcache.validate_timestamps=0
-opcache.blacklist_filename=/etc/php8/blacklist.txt
+opcache.blacklist_filename=/etc/php83/blacklist.txt


### PR DESCRIPTION
# Proposed Changes

The path that we used to disable opcache was incorrect

## Related Issues

Identified it when working on #476 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated configuration to use the correct blacklist file path for PHP 8.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->