### PR TITLE
Drop support for armv7 systems

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -13,7 +13,7 @@
       "matchStrings": [
         "ARG BUILD_FROM=(?<depName>.*?):(?<currentValue>.*?)\\s+",
         "ARG BUILDER=(?<depName>.*?):(?<currentValue>.*?)\\s+",
-        "(aarch64|amd64|armhf|armv7|i386):\\s[\"']?(?<depName>.*?):(?<currentValue>.*?)[\"']?\\s"
+        "(aarch64|amd64):\\s[\"']?(?<depName>.*?):(?<currentValue>.*?)[\"']?\\s"
       ],
       "datasourceTemplate": "docker"
     },

--- a/README.md
+++ b/README.md
@@ -6,9 +6,6 @@
 
 ![Supports aarch64 Architecture][aarch64-shield]
 ![Supports amd64 Architecture][amd64-shield]
-![Supports armhf Architecture][armhf-shield]
-![Supports armv7 Architecture][armv7-shield]
-![Supports i386 Architecture][i386-shield]
 
 [![Github Actions][github-actions-shield]][github-actions]
 ![Project Maintenance][maintenance-shield]
@@ -104,8 +101,6 @@ SOFTWARE.
 
 [aarch64-shield]: https://img.shields.io/badge/aarch64-yes-green.svg
 [amd64-shield]: https://img.shields.io/badge/amd64-yes-green.svg
-[armhf-shield]: https://img.shields.io/badge/armhf-no-red.svg
-[armv7-shield]: https://img.shields.io/badge/armv7-yes-green.svg
 [commits-shield]: https://img.shields.io/github/commit-activity/y/hassio-addons/addon-tasmoadmin.svg
 [commits]: https://github.com/hassio-addons/addon-tasmoadmin/commits/main
 [contributors]: https://github.com/hassio-addons/addon-tasmoadmin/graphs/contributors
@@ -120,7 +115,6 @@ SOFTWARE.
 [github-actions]: https://github.com/hassio-addons/addon-tasmoadmin/actions
 [github-sponsors-shield]: https://frenck.dev/wp-content/uploads/2019/12/github_sponsor.png
 [github-sponsors]: https://github.com/sponsors/frenck
-[i386-shield]: https://img.shields.io/badge/i386-no-red.svg
 [issue]: https://github.com/hassio-addons/addon-tasmoadmin/issues
 [license-shield]: https://img.shields.io/github/license/hassio-addons/addon-tasmoadmin.svg
 [maintenance-shield]: https://img.shields.io/maintenance/yes/2025.svg

--- a/tasmoadmin/build.yaml
+++ b/tasmoadmin/build.yaml
@@ -2,4 +2,3 @@
 build_from:
   aarch64: ghcr.io/hassio-addons/base:18.2.1
   amd64: ghcr.io/hassio-addons/base:18.2.1
-  armv7: ghcr.io/hassio-addons/base:18.2.1

--- a/tasmoadmin/config.yaml
+++ b/tasmoadmin/config.yaml
@@ -10,7 +10,6 @@ init: false
 arch:
   - aarch64
   - amd64
-  - armv7
 map:
   - ssl
 ports:


### PR DESCRIPTION
# Proposed Changes

The Home Assistant project has deprecated support for the armv7 architecture, and fully dropping it in the Home Assistant 2025.12 release.